### PR TITLE
GitHub Pages へのビルド・デプロイ

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,6 +33,17 @@ jobs:
         run: npm run build
         env:
           GITHUB_PAGES: 'true'
+          VITE_ENTRA_CLIENT_ID: ${{ vars.VITE_ENTRA_CLIENT_ID }}
+          VITE_ENTRA_TENANT: ${{ vars.VITE_ENTRA_TENANT }}
+          VITE_ENTRA_SCOPES: ${{ vars.VITE_ENTRA_SCOPES }}
+          VITE_GRAPH_SCOPES: ${{ vars.VITE_GRAPH_SCOPES }}
+          VITE_SP_SITE_ID: ${{ vars.VITE_SP_SITE_ID }}
+          VITE_SP_PUNCH_LIST_ID: ${{ vars.VITE_SP_PUNCH_LIST_ID }}
+          VITE_SP_ATTENDANCE_LIST_ID: ${{ vars.VITE_SP_ATTENDANCE_LIST_ID }}
+          VITE_SP_WORK_RULE_LIST_ID: ${{ vars.VITE_SP_WORK_RULE_LIST_ID }}
+          VITE_SP_WORK_CATEGORY_LIST_ID: ${{ vars.VITE_SP_WORK_CATEGORY_LIST_ID }}
+          VITE_GCAL_API_KEY: ${{ secrets.VITE_GCAL_API_KEY }}
+          VITE_GCAL_HOLIDAY_CALENDAR_ID: ${{ vars.VITE_GCAL_HOLIDAY_CALENDAR_ID }}
       - name: SPA 404 fallback
         run: cp dist/index.html dist/404.html
       - name: Upload artifact


### PR DESCRIPTION
## 概要
- GitHub Pages 向け Actions ワークフローを追加
- Environment の Secrets/Variables を build に注入
- Vite の base を Pages 用に切替
- SPA 404 フォールバックを追加

## 影響範囲
- vite.config.ts
- .github/workflows/deploy-pages.yml

## 動作確認
- 
> employee-time-attendance@0.0.0 build
> tsc -b && vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 2127 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                                    0.41 kB │ gzip:   0.27 kB
dist/assets/index-QDGuQ1Vn.css                                    23.65 kB │ gzip:   5.52 kB
dist/assets/FloatingTanStackRouterDevtools-B7vy70jP-B3IDdlTj.js   56.84 kB │ gzip:  16.73 kB
dist/assets/index-DZ1RBjQv.js                                    775.31 kB │ gzip: 229.73 kB
✓ built in 4.05s

## 関連
- Closes #9